### PR TITLE
updates from C++ upstream

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -1,0 +1,35 @@
+version: "0.2"
+words:
+  - abled
+  - adafruit
+  - addopts
+  - armv
+  - baudrate
+  - blinka
+  - busdevice
+  - busio
+  - capsys
+  - circuitpython
+  - digitalio
+  - Disabl
+  - Doherty
+  - elif
+  - Fals
+  - hexlified
+  - HHHBB
+  - Kbps
+  - LENG
+  - levelname
+  - Mbps
+  - micropython
+  - minversion
+  - MOSI
+  - multicasted
+  - multicasting
+  - multicasts
+  - mypy
+  - pytest
+  - raspberrypi
+  - setuptools
+  - spidev
+  - testpaths

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -38,3 +38,4 @@ words:
   - spidev
   - testpaths
   - urandom
+  - xfer

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -5,31 +5,53 @@ words:
   - addopts
   - armv
   - ATSAMD
+  - autoattribute
+  - autoclass
+  - autofunction
+  - automethod
+  - automodule
+  - autoproperty
   - baudrate
+  - bgcolor
   - blinka
   - busdevice
   - busio
+  - bysource
+  - bytearray
   - capsys
+  - CELLBORDER
+  - CELLSPACING
   - CIRCUITPY
   - circuitpython
+  - coef
   - datasheet
+  - dhcplist
   - digitalio
   - Disabl
   - Dmitry
+  - docstitle
   - Doherty
   - Eddystone
   - elif
   - Fals
+  - fontcolor
+  - fontname
+  - fontsize
+  - graphviz
   - Grinberg
   - hexlified
   - HHHBB
   - Hinch
+  - intersphinx
+  - isascii
   - Itsy
   - Kbps
+  - labelloc
   - LENG
   - levelname
   - Mbps
   - microcontroller
+  - microcontrollers
   - micropython
   - minversion
   - MOSI
@@ -38,16 +60,29 @@ words:
   - multicasts
   - multiceiver
   - mypy
+  - newrank
+  - penwidth
   - Pinout
+  - Pluss
   - pytest
+  - ranksep
   - raspberrypi
+  - repr
+  - rgba
   - Rhys
+  - Roboto
   - seealso
+  - setlinewidth
   - setuptools
+  - sparkfun
   - spidev
   - testpaths
   - toctree
+  - twopi
   - urandom
   - venv
   - versionadded
+  - versionchanged
+  - viewcode
+  - WLAN
   - xfer

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -10,7 +10,9 @@ words:
   - busdevice
   - busio
   - capsys
+  - CIRCUITPY
   - circuitpython
+  - datasheet
   - digitalio
   - Disabl
   - Dmitry
@@ -21,21 +23,31 @@ words:
   - Grinberg
   - hexlified
   - HHHBB
+  - Hinch
+  - Itsy
   - Kbps
   - LENG
   - levelname
   - Mbps
+  - microcontroller
   - micropython
   - minversion
   - MOSI
   - multicasted
   - multicasting
   - multicasts
+  - multiceiver
   - mypy
+  - Pinout
   - pytest
   - raspberrypi
+  - Rhys
+  - seealso
   - setuptools
   - spidev
   - testpaths
+  - toctree
   - urandom
+  - venv
+  - versionadded
   - xfer

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -4,6 +4,7 @@ words:
   - adafruit
   - addopts
   - armv
+  - ATSAMD
   - baudrate
   - blinka
   - busdevice
@@ -12,9 +13,12 @@ words:
   - circuitpython
   - digitalio
   - Disabl
+  - Dmitry
   - Doherty
+  - Eddystone
   - elif
   - Fals
+  - Grinberg
   - hexlified
   - HHHBB
   - Kbps
@@ -33,3 +37,4 @@ words:
   - setuptools
   - spidev
   - testpaths
+  - urandom

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         exclude: ^docs/social_cards/layouts
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.11.8
     hooks:
       # Run the linter.
       - id: ruff
@@ -19,7 +19,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         name: mypy (library code)

--- a/circuitpython_nrf24l01/fake_ble.py
+++ b/circuitpython_nrf24l01/fake_ble.py
@@ -195,7 +195,7 @@ class FakeBLE(RF24):
         self._addr_len = 4  # use only 4 byte address length
         self._tx_address[:4] = b"\x71\x91\x7d\x6b"
         with self:
-            super().open_rx_pipe(0, b"\x71\x91\x7d\x6b\0")
+            super().open_rx_pipe(1, b"\x71\x91\x7d\x6b\0")
         #: The internal queue of received BLE payloads' data.
         self.rx_queue: List[QueueElement] = []
         self.rx_cache: bytearray = bytearray(0)

--- a/circuitpython_nrf24l01/network/constants.py
+++ b/circuitpython_nrf24l01/network/constants.py
@@ -73,3 +73,11 @@ MSG_FRAG_FIRST = const(148)
 MSG_FRAG_MORE = const(149)
 #: Used to indicate the last frame of a fragmented message.
 MSG_FRAG_LAST = const(150)
+
+# error types used in `header.reserved` attribute
+NETWORK_OVERRUN = const(160)
+"""Used to indicate that the network was overrun and `RF24Network.available()`
+had to exit the internal loop when processing the radio's RX FIFO.
+"""
+#: Used to indicate the radio's RX FIFO had somehow been corrupted.
+NETWORK_CORRUPTION = const(161)

--- a/circuitpython_nrf24l01/rf24.py
+++ b/circuitpython_nrf24l01/rf24.py
@@ -134,7 +134,7 @@ class RF24:
 
     def __enter__(self):
         self._ce_pin.value = False
-        self._config |= 2
+        self._config = (self._config & 0xFC) | 2
         if self._aa & 1:
             self._open_pipes |= 1
             self._reg_write_bytes(_RX_ADDR_P0, self._tx_address)
@@ -148,12 +148,13 @@ class RF24:
         self._reg_write(_SETUP_RETR, self._retry_setup)
         for i, addr in enumerate(self._pipes):
             self.set_payload_length(self._pl_len[i], i)
-            if not i:  # skip pipe 0 RX address because we're going into TX mode
+            if not i and self._aa & 1:
+                # skip pipe 0 RX address because we're going into TX mode
                 continue
-            if i == 1:
+            elif i < 2:
                 self._reg_write_bytes(_RX_ADDR_P0 + i, addr)
             else:
-                self._reg_write(_RX_ADDR_P0 + i + 1, addr)
+                self._reg_write(_RX_ADDR_P0 + i, addr)
         self._reg_write_bytes(_TX_ADDR, self._tx_address)
         self._reg_write(0x05, self._channel)
         self._reg_write(0x03, self._addr_len - 2)

--- a/circuitpython_nrf24l01/rf24.py
+++ b/circuitpython_nrf24l01/rf24.py
@@ -174,7 +174,8 @@ class RF24:
             # time.sleep(0.000005)
             spi.write_readinto(self._out, self._in, out_end=len, in_end=len)
         # if command:
-        #     print("SPI command", ("%02X" % reg))
+        #     if reg != 0xFF:
+        #         print("SPI command", ("%02X" % reg))
         # else:
         #     print(
         #         "SPI read", len, "byte from", ("%02X" % reg), ("%02X" % self._in[1])
@@ -210,8 +211,7 @@ class RF24:
         with self._spi as spi:
             # time.sleep(0.000005)
             spi.write_readinto(self._out, self._in, out_end=buf_len, in_end=buf_len)
-        # if reg != 0xFF:
-        #     print("SPI write 1 byte to", ("%02X" % reg), ("%02X" % value))
+        # print("SPI write 1 byte to", ("%02X" % reg), ("%02X" % value))
 
     @property
     def address_length(self) -> int:

--- a/circuitpython_nrf24l01/rf24.py
+++ b/circuitpython_nrf24l01/rf24.py
@@ -45,7 +45,7 @@ _RX_PW_P0 = const(0x11)  # RX payload widths; pipes 0-5 = 0x11-0x16
 _DYN_PL = const(0x1C)  # dynamic payloads status for all pipes
 _FEATURE = const(0x1D)  # dynamic TX-payloads, TX-ACK payloads, TX-NO_ACK
 
-# various states of A radio's FIFO.
+# various states of a radio's FIFO.
 #: A constant to represent a FIFO state when it is full.
 FIFO_OCCUPIED = const(0)
 #: A constant to represent a FIFO state when it is empty.
@@ -100,8 +100,7 @@ class RF24:
         self._open_pipes, self._is_plus_variant = (0, False)  # close all RX pipes
         self._features = self._reg_read(_FEATURE)
         # invoke derelict command toggles TX_FEATURE register (test for plus variant)
-        self._out[0] = 0x50
-        self._out[1] = 0x73
+        self._out[:2] = bytes([0x50, 0x73])
         with self._spi as _spi:
             _spi.write_readinto(self._out, self._in, in_end=2, out_end=2)
         after_toggle = self._reg_read(_FEATURE)
@@ -274,7 +273,7 @@ class RF24:
     @property
     def listen(self) -> bool:
         """This attribute is the primary role as a radio."""
-        return self._config & 3 == 3
+        return bool(self._config & 1)
 
     @listen.setter
     def listen(self, is_rx: bool):

--- a/circuitpython_nrf24l01/rf24.py
+++ b/circuitpython_nrf24l01/rf24.py
@@ -34,16 +34,25 @@ from digitalio import DigitalInOut  # type: ignore[import]
 import busio  # type: ignore[import]
 from .wrapper import SPIDevCtx, SPIDevice
 
-CONFIGURE = const(0x00)  # IRQ masking, CRC scheme, PWR control, & RX/TX roles
-AUTO_ACK = const(0x01)  # auto-ACK status for all pipes
-OPEN_PIPES = const(0x02)  # open/close RX status for all pipes
-SETUP_RETR = const(0x04)  # auto-retry count & delay values
-RF_PA_RATE = const(0x06)  # RF Power Amplifier & Data Rate values
-RX_ADDR_P0 = const(0x0A)  # RX pipe addresses; pipes 0-5 = 0x0A-0x0F
-TX_ADDRESS = const(0x10)  # Address used for TX transmissions
-RX_PL_LENG = const(0x11)  # RX payload widths; pipes 0-5 = 0x11-0x16
-DYN_PL_LEN = const(0x1C)  # dynamic payloads status for all pipes
-TX_FEATURE = const(0x1D)  # dynamic TX-payloads, TX-ACK payloads, TX-NO_ACK
+_CONFIG = const(0x00)  # IRQ masking, CRC scheme, PWR control, & RX/TX roles
+_EN_AA = const(0x01)  # auto-ACK status for all pipes
+_EN_RX = const(0x02)  # open/close RX status for all pipes
+_SETUP_RETR = const(0x04)  # auto-retry count & delay values
+_RF_SETUP = const(0x06)  # RF Power Amplifier & Data Rate values
+_RX_ADDR_P0 = const(0x0A)  # RX pipe addresses; pipes 0-5 = 0x0A-0x0F
+_TX_ADDR = const(0x10)  # Address used for TX transmissions
+_RX_PW_P0 = const(0x11)  # RX payload widths; pipes 0-5 = 0x11-0x16
+_DYN_PL = const(0x1C)  # dynamic payloads status for all pipes
+_FEATURE = const(0x1D)  # dynamic TX-payloads, TX-ACK payloads, TX-NO_ACK
+
+# various states of A radio's FIFO.
+#: A constant to represent a FIFO state when it is full.
+FIFO_OCCUPIED = const(0)
+#: A constant to represent a FIFO state when it is empty.
+FIFO_EMPTY = const(1)
+FIFO_FULL = const(2)
+"""A constant to represent a FIFO state when it neither full nor empty
+(contains 1 or 2 payloads)."""
 
 
 def address_repr(
@@ -78,24 +87,24 @@ class RF24:
             self._spi = SPIDevCtx(spi, csn, spi_frequency=spi_frequency)
         else:
             self._spi = SPIDevice(spi, chip_select=csn, baudrate=spi_frequency)
-        self._reg_write(CONFIGURE, self._config)
-        if self._reg_read(CONFIGURE) != self._config:
+        self._reg_write(_CONFIG, self._config)
+        if self._reg_read(_CONFIG) != self._config:
             raise RuntimeError("radio hardware not responding")
         for i in range(6):  # capture RX addresses from registers
             if i < 2:
-                self._pipes[i] = self._reg_read_bytes(RX_ADDR_P0 + i)
+                self._pipes[i] = self._reg_read_bytes(_RX_ADDR_P0 + i)
             else:
-                self._pipes[i] = self._reg_read(RX_ADDR_P0 + i)
+                self._pipes[i] = self._reg_read(_RX_ADDR_P0 + i)
         # test is nRF24L01 is a plus variant using a command specific to
         # non-plus variants
         self._open_pipes, self._is_plus_variant = (0, False)  # close all RX pipes
-        self._features = self._reg_read(TX_FEATURE)
+        self._features = self._reg_read(_FEATURE)
         # invoke derelict command toggles TX_FEATURE register (test for plus variant)
         self._out[0] = 0x50
         self._out[1] = 0x73
         with self._spi as _spi:
             _spi.write_readinto(self._out, self._in, in_end=2, out_end=2)
-        after_toggle = self._reg_read(TX_FEATURE)
+        after_toggle = self._reg_read(_FEATURE)
         if self._features == after_toggle:
             self._is_plus_variant = True
         elif not after_toggle:  # if features are disabled
@@ -108,7 +117,7 @@ class RF24:
         # open_tx_pipe() appropriates pipe 0 for ACK packet
         self._is_p0_rx: bool = False
         # shadow copy of the TX_ADDRESS
-        self._tx_address = self._reg_read_bytes(TX_ADDRESS)
+        self._tx_address = self._reg_read_bytes(_TX_ADDR)
         # pre-configure the SETUP_RETR register
         self._retry_setup = 0x5F  # ard = 1500; arc = 15
         # pre-configure the RF_SETUP register
@@ -129,24 +138,24 @@ class RF24:
         self._config |= 2
         if self._aa & 1:
             self._open_pipes |= 1
-            self._reg_write_bytes(RX_ADDR_P0, self._tx_address)
-        self._reg_write(CONFIGURE, self._config)
+            self._reg_write_bytes(_RX_ADDR_P0, self._tx_address)
+        self._reg_write(_CONFIG, self._config)
         # time.sleep(0.00015)  # let the rest of this function be the delay
-        self._reg_write(RF_PA_RATE, self._rf_setup)
-        self._reg_write(OPEN_PIPES, self._open_pipes)
-        self._reg_write(DYN_PL_LEN, self._dyn_pl)
-        self._reg_write(AUTO_ACK, self._aa)
-        self._reg_write(TX_FEATURE, self._features)
-        self._reg_write(SETUP_RETR, self._retry_setup)
+        self._reg_write(_RF_SETUP, self._rf_setup)
+        self._reg_write(_EN_RX, self._open_pipes)
+        self._reg_write(_DYN_PL, self._dyn_pl)
+        self._reg_write(_EN_AA, self._aa)
+        self._reg_write(_FEATURE, self._features)
+        self._reg_write(_SETUP_RETR, self._retry_setup)
         for i, addr in enumerate(self._pipes):
             self.set_payload_length(self._pl_len[i], i)
             if not i:  # skip pipe 0 RX address because we're going into TX mode
                 continue
             if i == 1:
-                self._reg_write_bytes(RX_ADDR_P0 + i, addr)
+                self._reg_write_bytes(_RX_ADDR_P0 + i, addr)
             else:
-                self._reg_write(RX_ADDR_P0 + i + 1, addr)
-        self._reg_write_bytes(TX_ADDRESS, self._tx_address)
+                self._reg_write(_RX_ADDR_P0 + i + 1, addr)
+        self._reg_write_bytes(_TX_ADDR, self._tx_address)
         self._reg_write(0x05, self._channel)
         self._reg_write(0x03, self._addr_len - 2)
         return self
@@ -154,7 +163,7 @@ class RF24:
     def __exit__(self, *exc):
         self._ce_pin.value = False
         self._config &= 0x7D  # power off radio
-        self._reg_write(CONFIGURE, self._config)
+        self._reg_write(_CONFIG, self._config)
         time.sleep(0.00015)
         return False
 
@@ -230,17 +239,17 @@ class RF24:
         addr = address[:addr_len]
         self._tx_address[:addr_len] = addr
         if self._config & 1 == 0 and self._aa & 1:
-            self._reg_write_bytes(RX_ADDR_P0, addr)
-        self._reg_write_bytes(TX_ADDRESS, addr)
+            self._reg_write_bytes(_RX_ADDR_P0, addr)
+        self._reg_write_bytes(_TX_ADDR, addr)
 
     def close_rx_pipe(self, pipe_number: int) -> None:
         """Close a specific data pipe from RX transmissions."""
         if pipe_number < 0 or pipe_number > 5:
             raise IndexError("pipe number must be in range [0, 5]")
-        self._open_pipes = self._reg_read(OPEN_PIPES) & ~(1 << pipe_number)
+        self._open_pipes = self._reg_read(_EN_RX) & ~(1 << pipe_number)
         if not pipe_number:
             self._is_p0_rx = False
-        self._reg_write(OPEN_PIPES, self._open_pipes)
+        self._reg_write(_EN_RX, self._open_pipes)
 
     def open_rx_pipe(self, pipe_number: int, address: Union[bytes, bytearray]) -> None:
         """Open a specific data pipe for RX transmissions."""
@@ -255,12 +264,12 @@ class RF24:
                 self._is_p0_rx = True
             self._pipes[pipe_number][:addr_len] = addr  # type: ignore[assignment, index]
             if self._config & 1 or pipe_number != 0:
-                self._reg_write_bytes(RX_ADDR_P0 + pipe_number, addr)
+                self._reg_write_bytes(_RX_ADDR_P0 + pipe_number, addr)
         else:
             self._pipes[pipe_number] = addr[0]
-            self._reg_write(RX_ADDR_P0 + pipe_number, address[0])
-        self._open_pipes = self._reg_read(OPEN_PIPES) | (1 << pipe_number)
-        self._reg_write(OPEN_PIPES, self._open_pipes)
+            self._reg_write(_RX_ADDR_P0 + pipe_number, address[0])
+        self._open_pipes = self._reg_read(_EN_RX) | (1 << pipe_number)
+        self._reg_write(_EN_RX, self._open_pipes)
 
     @property
     def listen(self) -> bool:
@@ -271,23 +280,23 @@ class RF24:
     def listen(self, is_rx: bool):
         self._ce_pin.value = False
         self._config = self._config & 0xFC | (2 + bool(is_rx))
-        self._reg_write(CONFIGURE, self._config)
+        self._reg_write(_CONFIG, self._config)
         start_timer = time.monotonic_ns()
         if is_rx:
             self._ce_pin.value = True
             if self._is_p0_rx:
-                self._reg_write_bytes(RX_ADDR_P0, self._pipes[0][: self._addr_len])  # type: ignore[index]
+                self._reg_write_bytes(_RX_ADDR_P0, self._pipes[0][: self._addr_len])  # type: ignore[index]
             elif self._open_pipes & 1:
                 self._open_pipes &= 0x3E  # close_rx_pipe(0) is slower
-                self._reg_write(OPEN_PIPES, self._open_pipes)
+                self._reg_write(_EN_RX, self._open_pipes)
         else:
             if self._features & 6 == 6:
                 self.flush_tx()
             if self._aa & 1:
-                self._reg_write_bytes(RX_ADDR_P0, self._tx_address[: self._addr_len])
+                self._reg_write_bytes(_RX_ADDR_P0, self._tx_address[: self._addr_len])
                 if not self._open_pipes & 1:
                     self._open_pipes |= 1
-                    self._reg_write(OPEN_PIPES, self._open_pipes)
+                    self._reg_write(_EN_RX, self._open_pipes)
         # mandatory wait time is 130 µs
         delta_time = time.monotonic_ns() - start_timer
         if delta_time < 150000:
@@ -393,22 +402,22 @@ class RF24:
         self, data_recv: bool = True, data_sent: bool = True, data_fail: bool = True
     ):
         """Sets the configuration of the nRF24L01's IRQ pin. (write-only)"""
-        self._config = (self._reg_read(CONFIGURE) & 0x0F) | (not data_recv) << 6
+        self._config = (self._reg_read(_CONFIG) & 0x0F) | (not data_recv) << 6
         self._config |= (not data_fail) << 4 | (not data_sent) << 5
-        self._reg_write(CONFIGURE, self._config)
+        self._reg_write(_CONFIG, self._config)
 
     def print_details(self, dump_pipes: bool = False) -> None:
         """This debugging function outputs all details about the nRF24L01."""
         observer = self._reg_read(8)
         _fifo = self._reg_read(0x17)
-        self._config = self._reg_read(CONFIGURE)
-        self._rf_setup = self._reg_read(RF_PA_RATE)
-        self._retry_setup = self._reg_read(SETUP_RETR)
+        self._config = self._reg_read(_CONFIG)
+        self._rf_setup = self._reg_read(_RF_SETUP)
+        self._retry_setup = self._reg_read(_SETUP_RETR)
         self._channel = self.channel
         self._addr_len = self._reg_read(0x03) + 2
-        self._features = self._reg_read(TX_FEATURE)
-        self._aa = self._reg_read(AUTO_ACK)
-        self._dyn_pl = self._reg_read(DYN_PL_LEN)
+        self._features = self._reg_read(_FEATURE)
+        self._aa = self._reg_read(_EN_AA)
+        self._dyn_pl = self._reg_read(_DYN_PL)
         _crc = (
             (2 if self._config & 4 else 1)
             if self._aa
@@ -504,14 +513,14 @@ class RF24:
     def print_pipes(self) -> None:
         """Prints all information specific to pipe's addresses, RX state, & expected
         static payload sizes (if configured to use static payloads)."""
-        self._open_pipes = self._reg_read(OPEN_PIPES)
-        self._tx_address = self._reg_read_bytes(TX_ADDRESS)
+        self._open_pipes = self._reg_read(_EN_RX)
+        self._tx_address = self._reg_read_bytes(_TX_ADDR)
         for i in range(6):
             if i < 2:
-                self._pipes[i] = self._reg_read_bytes(RX_ADDR_P0 + i)
+                self._pipes[i] = self._reg_read_bytes(_RX_ADDR_P0 + i)
             else:
-                self._pipes[i] = self._reg_read(RX_ADDR_P0 + i)
-            self._pl_len[i] = self._reg_read(RX_PL_LENG + i)
+                self._pipes[i] = self._reg_read(_RX_ADDR_P0 + i)
+            self._pl_len[i] = self._reg_read(_RX_PW_P0 + i)
         print("TX address____________ 0x{}".format(address_repr(self.address())))
         for i in range(6):
             is_open = self._open_pipes & (1 << i)
@@ -532,33 +541,33 @@ class RF24:
     def dynamic_payloads(self) -> int:
         """This `int` attribute is the dynamic payload length feature for
         any/all pipes."""
-        self._dyn_pl = self._reg_read(DYN_PL_LEN)
+        self._dyn_pl = self._reg_read(_DYN_PL)
         return self._dyn_pl
 
     @dynamic_payloads.setter
     def dynamic_payloads(self, enable: Union[int, bool, Sequence[bool]]):
-        self._features = self._reg_read(TX_FEATURE)
+        self._features = self._reg_read(_FEATURE)
         if isinstance(enable, bool):
             self._dyn_pl = 0x3F if enable else 0
         elif isinstance(enable, int):
             self._dyn_pl = 0x3F & enable
         elif isinstance(enable, (list, tuple)):
-            self._dyn_pl = self._reg_read(DYN_PL_LEN)
+            self._dyn_pl = self._reg_read(_DYN_PL)
             for i, val in enumerate(enable):
                 if i < 6 and val >= 0:  # skip pipe if val is negative
                     self._dyn_pl = (self._dyn_pl & ~(1 << i)) | (bool(val) << i)
         else:
             raise ValueError("dynamic_payloads: {} is an invalid input".format(enable))
         self._features = (self._features & 3) | (bool(self._dyn_pl) << 2)
-        self._reg_write(TX_FEATURE, self._features)
-        self._reg_write(DYN_PL_LEN, self._dyn_pl)
+        self._reg_write(_FEATURE, self._features)
+        self._reg_write(_DYN_PL, self._dyn_pl)
 
     def set_dynamic_payloads(self, enable: bool, pipe_number: Optional[int] = None):
         """Control the dynamic payload feature for a specific data pipe."""
         if pipe_number is None:
             self.dynamic_payloads = bool(enable)
         elif 0 <= pipe_number <= 5:
-            self._dyn_pl = self._reg_read(DYN_PL_LEN) & ~(1 << pipe_number)
+            self._dyn_pl = self._reg_read(_DYN_PL) & ~(1 << pipe_number)
             self.dynamic_payloads = self._dyn_pl | (bool(enable) << pipe_number)
         else:
             raise IndexError("pipe_number must be in range [0, 5]")
@@ -583,7 +592,7 @@ class RF24:
         for i, val in enumerate(length):
             if i < 6 and val > 0:  # don't throw exception, just skip pipe
                 self._pl_len[i] = min(32, val)
-                self._reg_write(RX_PL_LENG + i, self._pl_len[i])
+                self._reg_write(_RX_PW_P0 + i, self._pl_len[i])
 
     def set_payload_length(self, length: int, pipe_number: Optional[int] = None):
         """Sets the static payload length feature for each/all data pipes."""
@@ -591,45 +600,45 @@ class RF24:
             self.payload_length = length
         else:
             self._pl_len[pipe_number] = max(1, min(32, length))
-            self._reg_write(RX_PL_LENG + pipe_number, length)
+            self._reg_write(_RX_PW_P0 + pipe_number, length)
 
     def get_payload_length(self, pipe_number: int = 0) -> int:
         """Returns an `int` describing the specified data pipe's static
         payload length."""
-        self._pl_len[pipe_number] = self._reg_read(RX_PL_LENG + pipe_number)
+        self._pl_len[pipe_number] = self._reg_read(_RX_PW_P0 + pipe_number)
         return self._pl_len[pipe_number]
 
     @property
     def arc(self) -> int:
         """This `int` attribute specifies the number of attempts to
         re-transmit TX payload when ACK packet is not received."""
-        self._retry_setup = self._reg_read(SETUP_RETR)
+        self._retry_setup = self._reg_read(_SETUP_RETR)
         return self._retry_setup & 0x0F
 
     @arc.setter
     def arc(self, count: int):
         count = max(0, min(int(count), 15))
         self._retry_setup = (self._retry_setup & 0xF0) | count
-        self._reg_write(SETUP_RETR, self._retry_setup)
+        self._reg_write(_SETUP_RETR, self._retry_setup)
 
     @property
     def ard(self) -> int:
         """This `int` attribute specifies the delay (in microseconds) between attempts
         to automatically re-transmit the TX payload when no ACK packet is received."""
-        self._retry_setup = self._reg_read(SETUP_RETR)
+        self._retry_setup = self._reg_read(_SETUP_RETR)
         return ((self._retry_setup & 0xF0) >> 4) * 250 + 250
 
     @ard.setter
     def ard(self, delta: int):
         delta = max(250, min(delta, 4000))
         self._retry_setup = (self._retry_setup & 15) | int((delta - 250) / 250) << 4
-        self._reg_write(SETUP_RETR, self._retry_setup)
+        self._reg_write(_SETUP_RETR, self._retry_setup)
 
     def set_auto_retries(self, delay: int, count: int):
         """set the `ard` & `arc` attributes with 1 function."""
         delay = int((max(250, min(delay, 4000)) - 250) / 250) << 4
         self._retry_setup = delay | max(0, min(int(count), 15))
-        self._reg_write(SETUP_RETR, self._retry_setup)
+        self._reg_write(_SETUP_RETR, self._retry_setup)
 
     def get_auto_retries(self) -> tuple:
         """get the `ard` & `arc` attributes with 1 function."""
@@ -644,7 +653,7 @@ class RF24:
     def auto_ack(self) -> int:
         """This `int` attribute is the automatic acknowledgment feature for
         any/all pipes."""
-        self._aa = self._reg_read(AUTO_ACK)
+        self._aa = self._reg_read(_EN_AA)
         return self._aa
 
     @auto_ack.setter
@@ -654,20 +663,20 @@ class RF24:
         elif isinstance(enable, int):
             self._aa = 0x3F & enable
         elif isinstance(enable, (list, tuple)):
-            self._aa = self._reg_read(AUTO_ACK)
+            self._aa = self._reg_read(_EN_AA)
             for i, val in enumerate(enable):
                 if i < 6 and val >= 0:  # skip pipe if val is negative
                     self._aa = (self._aa & ~(1 << i)) | (bool(val) << i)
         else:
             raise ValueError("auto_ack: {} is not a valid input".format(enable))
-        self._reg_write(AUTO_ACK, self._aa)
+        self._reg_write(_EN_AA, self._aa)
 
     def set_auto_ack(self, enable: bool, pipe_number: Optional[int] = None):
         """Control the `auto_ack` feature for a specific data pipe."""
         if pipe_number is None:
             self.auto_ack = bool(enable)
         elif 0 <= pipe_number <= 5:
-            self._aa = self._reg_read(AUTO_ACK) & ~(1 << pipe_number)
+            self._aa = self._reg_read(_EN_AA) & ~(1 << pipe_number)
             self.auto_ack = self._aa | (bool(enable) << pipe_number)
         else:
             raise IndexError("pipe_number must be in range [0, 5]")
@@ -675,16 +684,16 @@ class RF24:
     def get_auto_ack(self, pipe_number: int) -> bool:
         """Returns a `bool` describing the `auto_ack` feature about a data pipe."""
         if 0 <= pipe_number <= 5:
-            self._aa = self._reg_read(AUTO_ACK)
+            self._aa = self._reg_read(_EN_AA)
             return bool(self._aa & (1 << pipe_number))
         raise IndexError("pipe_number must be in range [0, 5]")
 
     @property
     def ack(self) -> bool:
         """Represents use of custom payloads as part of the ACK packet."""
-        self._aa = self._reg_read(AUTO_ACK)
-        self._dyn_pl = self._reg_read(DYN_PL_LEN)
-        self._features = self._reg_read(TX_FEATURE)
+        self._aa = self._reg_read(_EN_AA)
+        self._dyn_pl = self._reg_read(_DYN_PL)
+        self._features = self._reg_read(_FEATURE)
         return bool((self._features & 6) == 6 and ((self._aa & self._dyn_pl) & 1))
 
     @ack.setter
@@ -692,10 +701,10 @@ class RF24:
         if bool(enable):
             self.set_auto_ack(True, 0)
             self._dyn_pl = self._dyn_pl & 0x3E | 1
-            self._reg_write(DYN_PL_LEN, self._dyn_pl)
+            self._reg_write(_DYN_PL, self._dyn_pl)
             self._features = self._features | 4
         self._features = self._features & 5 | bool(enable) << 1
-        self._reg_write(TX_FEATURE, self._features)
+        self._reg_write(_FEATURE, self._features)
 
     def load_ack(self, buf: Union[bytes, bytearray], pipe_number: int) -> bool:
         """Load a payload into the TX FIFO for use on a specific data pipe."""
@@ -711,18 +720,18 @@ class RF24:
     @property
     def allow_ask_no_ack(self) -> bool:
         """Allow or disable ``ask_no_ack`` parameter to `send()` & `write()`."""
-        self._features = self._reg_read(TX_FEATURE)
+        self._features = self._reg_read(_FEATURE)
         return bool(self._features & 1)
 
     @allow_ask_no_ack.setter
     def allow_ask_no_ack(self, enable: bool):
-        self._features = self._reg_read(TX_FEATURE) & 6 | bool(enable)
-        self._reg_write(TX_FEATURE, self._features)
+        self._features = self._reg_read(_FEATURE) & 6 | bool(enable)
+        self._reg_write(_FEATURE, self._features)
 
     @property
     def data_rate(self) -> int:
         """This `int` attribute specifies the RF data rate."""
-        self._rf_setup = self._reg_read(RF_PA_RATE)
+        self._rf_setup = self._reg_read(_RF_SETUP)
         rf_setup = self._rf_setup & 0x28
         return (2 if rf_setup == 8 else 250) if rf_setup else 1
 
@@ -731,8 +740,8 @@ class RF24:
         if speed not in (1, 2, 250):
             raise ValueError("data_rate must be 1 (Mbps), 2 (Mbps), or 250 (kbps)")
         speed = 0 if speed == 1 else (0x20 if speed != 2 else 8)
-        self._rf_setup = self._reg_read(RF_PA_RATE) & 0xD7 | speed
-        self._reg_write(RF_PA_RATE, self._rf_setup)
+        self._rf_setup = self._reg_read(_RF_SETUP) & 0xD7 | speed
+        self._reg_write(_RF_SETUP, self._rf_setup)
 
     @property
     def channel(self) -> int:
@@ -749,8 +758,8 @@ class RF24:
     @property
     def crc(self) -> int:
         """This `int` attribute specifies the CRC checksum length in bytes."""
-        self._config = self._reg_read(CONFIGURE)
-        self._aa = self._reg_read(AUTO_ACK)
+        self._config = self._reg_read(_CONFIG)
+        self._aa = self._reg_read(_EN_AA)
         if self._aa:
             return 2 if self._config & 4 else 1
         return max(0, ((self._config & 0x0C) >> 2) - 1)
@@ -760,24 +769,24 @@ class RF24:
         length = min(2, abs(int(length)))
         length = (length + 1) << 2 if length else 0
         self._config = self._config & 0x73 | length
-        self._reg_write(CONFIGURE, self._config)
+        self._reg_write(_CONFIG, self._config)
 
     @property
     def power(self) -> bool:
         """This `bool` attribute controls the power state of the nRF24L01."""
-        self._config = self._reg_read(CONFIGURE)
+        self._config = self._reg_read(_CONFIG)
         return bool(self._config & 2)
 
     @power.setter
     def power(self, is_on: bool):
-        self._config = self._reg_read(CONFIGURE) & 0x7D | bool(is_on) << 1
-        self._reg_write(CONFIGURE, self._config)
+        self._config = self._reg_read(_CONFIG) & 0x7D | bool(is_on) << 1
+        self._reg_write(_CONFIG, self._config)
         time.sleep(0.00015)
 
     @property
     def pa_level(self) -> int:
         """This `int` is the power amplifier level (in dBm)."""
-        self._rf_setup = self._reg_read(RF_PA_RATE)
+        self._rf_setup = self._reg_read(_RF_SETUP)
         return (3 - ((self._rf_setup & 6) >> 1)) * -6
 
     @pa_level.setter
@@ -789,12 +798,12 @@ class RF24:
             raise ValueError("pa_level must be -18, -12, -6, or 0 (in dBm)")
         pwr = (3 - int(power / -6)) * 2
         self._rf_setup = (self._rf_setup & 0xF8) | pwr | lna_bit
-        self._reg_write(RF_PA_RATE, self._rf_setup)
+        self._reg_write(_RF_SETUP, self._rf_setup)
 
     @property
     def is_lna_enabled(self) -> bool:
         """A read-only `bool` attribute about the LNA gain feature."""
-        self._rf_setup = self._reg_read(RF_PA_RATE)
+        self._rf_setup = self._reg_read(_RF_SETUP)
         return bool(self._rf_setup & 1)
 
     def resend(self, send_only: bool = False):
@@ -848,12 +857,16 @@ class RF24:
         """Flush all 3 levels of the TX FIFO."""
         self._reg_read(0xE1, command=True)
 
-    def fifo(self, about_tx: bool = False, check_empty: Optional[bool] = None):
+    def fifo(
+        self, about_tx: bool = False, check_empty: Optional[bool] = None
+    ) -> int | bool:
         """This provides the status of the TX/RX FIFO buffers. (read-only)"""
-        _fifo, about_tx = (self._reg_read(0x17), bool(about_tx))
+        _fifo = (self._reg_read(0x17) >> (4 * bool(about_tx))) & 3
+        if _fifo == 3:
+            raise RuntimeError("Binary corruption observed om SPI MISO line")
         if check_empty is None:
-            return (_fifo & (0x30 if about_tx else 0x03)) >> (4 * about_tx)
-        return bool(_fifo & ((2 - bool(check_empty)) << (4 * about_tx)))
+            return _fifo
+        return bool(_fifo & (2 - bool(check_empty)))
 
     def address(self, index: int = -1):
         """Returns the current TX address or optionally RX address. (read-only)"""
@@ -877,13 +890,13 @@ class RF24:
         self.power = True
         self.listen = False
         self._rf_setup |= 0x90
-        self._reg_write(RF_PA_RATE, self._rf_setup)
+        self._reg_write(_RF_SETUP, self._rf_setup)
         if not self.is_plus_variant:
-            self._reg_write(AUTO_ACK, 0)
-            self._reg_write(SETUP_RETR, 0)
-            self._reg_write_bytes(TX_ADDRESS, b"\xff" * 5)
+            self._reg_write(_EN_AA, 0)
+            self._reg_write(_SETUP_RETR, 0)
+            self._reg_write_bytes(_TX_ADDR, b"\xff" * 5)
             self._reg_write_bytes(0xA0, b"\xff" * 32)
-            self._reg_write(CONFIGURE, 0x73)
+            self._reg_write(_CONFIG, 0x73)
             self._ce_pin.value = True
             time.sleep(0.001)
             self._ce_pin.value = False
@@ -896,4 +909,4 @@ class RF24:
         self._ce_pin.value = False
         self.power = False
         self._rf_setup &= ~0x90
-        self._reg_write(RF_PA_RATE, self._rf_setup)
+        self._reg_write(_RF_SETUP, self._rf_setup)

--- a/circuitpython_nrf24l01/rf24.py
+++ b/circuitpython_nrf24l01/rf24.py
@@ -278,7 +278,7 @@ class RF24:
         else:
             if self._features & 6 == 6:
                 self.flush_tx()
-            if self._is_p0_rx and self._aa & 1:
+            if self._aa & 1:
                 self._reg_write_bytes(RX_ADDR_P0, self._tx_address[: self._addr_len])
                 if not self._open_pipes & 1:
                     self._open_pipes |= 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,12 +121,9 @@ html_theme = "sphinx_immaterial"
 
 html_theme_options = {
     "features": [
-        # "navigation.expand",
         "navigation.tabs",
-        # "toc.integrate",
         "navigation.sections",
         "navigation.instant",
-        # "header.autohide",
         "navigation.top",
         # "search.highlight",
         "search.share",
@@ -164,6 +161,13 @@ html_theme_options = {
     ],
     "palette": [
         {
+            "media": "(prefers-color-scheme)",
+            "toggle": {
+                "icon": "material/brightness-auto",
+                "name": "Switch to dark mode",
+            },
+        },
+        {
             "media": "(prefers-color-scheme: dark)",
             "scheme": "slate",
             "primary": "lime",
@@ -188,8 +192,6 @@ html_theme_options = {
     "site_url": html_baseurl,
     "repo_url": "https://github.com/nRF24/CircuitPython_nRF24L01/",
     "repo_name": "CircuitPython_nRF24L01",
-    # If False, expand all TOC entries
-    "globaltoc_collapse": False,
     "toc_title_is_page_title": True,
 }
 
@@ -262,6 +264,3 @@ html_favicon = "_static/new_favicon.ico"
 
 # project logo
 html_logo = "_static/Logo large.png"
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = "nRF24L01_Library_doc"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ html_baseurl = os.environ.get(
 # General information about the project.
 project = "CircuitPython nRF24L01"
 author = "Brendan Doherty"
-copyright = f'{time.strftime("%Y", time.localtime())} {author}'
+copyright = f"{time.strftime('%Y', time.localtime())} {author}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/core_api/advanced_api.rst
+++ b/docs/core_api/advanced_api.rst
@@ -286,7 +286,7 @@ Debugging Output
 
     :param buf: The buffer of bytes to convert into a hexlified
         string.
-    :param reverse: A `bool` to control the resulting endianess. `True`
+    :param reverse: A `bool` to control the resulting endianness. `True`
         outputs the result as big endian. `False` outputs the result as little
         endian. This parameter defaults to `True` since `bytearray` and `bytes`
         objects are stored in big endian but written in little endian.
@@ -416,8 +416,7 @@ Status Byte
         is an antiquated status flag (after you've dealt with the specific payload related to
         the status flags that were set), otherwise it can cause payloads to be ignored and
         occupy the RX/TX FIFO buffers. See `Appendix A of the nRF24L01+ Specifications Sheet
-        <https://www.sparkfun.com/datasheets/Components/SMD/
-        nRF24L01Pluss_Preliminary_Product_Specification_v1_0.pdf#G1047965>`_ for an outline of
+        <https://www.sparkfun.com/datasheets/Components/SMD/nRF24L01Pluss_Preliminary_Product_Specification_v1_0.pdf#G1047965>`_ for an outline of
         proper behavior.
 
 

--- a/docs/core_api/advanced_api.rst
+++ b/docs/core_api/advanced_api.rst
@@ -440,6 +440,10 @@ FIFO management
         successful transmission (see also `resend()` as the handling of failed transmissions
         can be altered).
 
+.. autodata:: circuitpython_nrf24l01.rf24.FIFO_EMPTY
+.. autodata:: circuitpython_nrf24l01.rf24.FIFO_FULL
+.. autodata:: circuitpython_nrf24l01.rf24.FIFO_OCCUPIED
+
 .. automethod:: circuitpython_nrf24l01.rf24.RF24.fifo
 
     :param about_tx:
@@ -452,15 +456,19 @@ FIFO management
         - `None` (when not specified) returns a 2 bit number representing both empty (bit 1) &
           full (bit 0) tests related to the FIFO buffer specified using the ``about_tx``
           parameter.
+    :throws: This will raise a `RuntimeError` when the data over the MISO line is corrupted.
     :returns:
         - A `bool` answer to the question:
 
           "Is the [TX/RX](``about_tx``) FIFO buffer [empty/full](``check_empty``)?
         - If the ``check_empty`` parameter is not specified: an `int` in range [0, 2] for which:
 
-          - ``1`` means the specified FIFO buffer is empty
-          - ``2`` means the specified FIFO buffer is full
-          - ``0`` means the specified FIFO buffer is neither full nor empty
+          - `FIFO_EMPTY` means the specified FIFO buffer is empty
+          - `FIFO_FULL` means the specified FIFO buffer is full
+          - `FIFO_OCCUPIED` means the specified FIFO buffer is neither full nor empty (1 or 2 payloads)
+
+    .. versionchanged:: 2.1.6
+        Throws a `RuntimeError` when binary corruption is observed on the SPI bus' MISO line.
 
 Ambiguous Signal Detection
 ******************************

--- a/docs/core_api/ble_api.rst
+++ b/docs/core_api/ble_api.rst
@@ -128,7 +128,7 @@ here has been adapted to work with CircuitPython.
 .. autofunction:: circuitpython_nrf24l01.fake_ble.whitener
 
     This is a helper function to `FakeBLE.whiten()`. It has been broken out of the
-    `FakeBLE` class to allow whitening and dewhitening a BLE payload without the
+    `FakeBLE` class to allow whitening and de-whitening a BLE payload without the
     hardcoded coefficient.
 
     :param buf: The BLE payloads data. This data should include the
@@ -220,7 +220,7 @@ FakeBLE class
 
     .. versionchanged:: 2.1.0 Invalid input ignored
 
-        Prevoiusly, any invalid input value (that is not found in `BLE_FREQ`) had raised a
+        Previously, any invalid input value (that is not found in `BLE_FREQ`) had raised a
         `ValueError` exception. This behavior changed to ignoring invalid input values,
         and the exception is no longer raised.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -176,7 +176,7 @@ to the MCU via a digital input pin during the interrupt example.
 
 .. tip::
     User reports and personal experiences have improved results if there is a capacitor of
-    100 microfarads (+ another optional 0.1 microfarads capacitor for added stability) connected
+    100 microfarad (+ another optional 0.1 microfarad capacitor for added stability) connected
     in parallel to the VCC and GND pins.
 .. important::
     The nRF24L01's VCC pin is not 5V compliant. All other nRF24L01 pins *should* be 5V compliant,
@@ -242,11 +242,9 @@ For CPython in Linux
 What to purchase
 =================
 
-See the following links to Sparkfun or just google "nRF24L01+".
-
-* `2.4GHz Transceiver IC - nRF24L01+ <https://www.sparkfun.com/products/690>`_
-* `SparkFun Transceiver Breakout - nRF24L01+ <https://www.sparkfun.com/products/691>`_
-* `SparkFun Transceiver Breakout - nRF24L01+ (RP-SMA) <https://www.sparkfun.com/products/705>`_
+Just do a Google search for the term "nRF24L01+".
+This chip is no longer recommended for new designs (since 2014),
+but it is still widely available from some less reputable online retailers (amazon.com included).
 
 It is worth noting that you
 generally want to buy more than 1 as you need 2 for testing -- 1 to send & 1 to receive and
@@ -266,8 +264,7 @@ then adding capacitor(s) (100 µF + an optional 0.1µF) in parallel (& as close
 as possible) to the VCC and GND pins is highly recommended. Stabilizing the power
 input provides significant performance increases. More finite details about the
 nRF24L01 are available from the datasheet (referenced here in the documentation as the
-`nRF24L01+ Specification Sheet <https://www.sparkfun.com/datasheets/
-Components/SMD/nRF24L01Pluss_Preliminary_Product_Specification_v1_0.pdf>`_)
+`nRF24L01+ Specification Sheet <https://github.com/nRF24/RF24/blob/beb8ffebc5be0f5470fb08c851f941d0c70a45e0/datasheets/nRF24L01_datasheet_v2.pdf>`_)
 
 About the nRF24L01+PA+LNA modules
 ---------------------------------
@@ -310,16 +307,14 @@ nRF24L01(+) clones and counterfeits
 This library does not directly support clones/counterfeits as there is no way for the library
 to differentiate between an actual nRF24L01+ and a clone/counterfeit. To determine if your
 purchase is a counterfeit, please contact the retailer you purchased from (also `reading this
-article and its links might help
-<https://hackaday.com/2015/02/23/nordic-nrf24l01-real-vs-fake/>`_). The most notable clone is the `Si24R1 <https://lcsc.com/product-detail/
-RF-Transceiver-ICs_Nanjing-Zhongke-Microelectronics-Si24R1_C14436.html>`_. I could not find
-the `Si24R1 datasheet <https://datasheet.lcsc.com/szlcsc/
-1811142211_Nanjing-Zhongke-Microelectronics-Si24R1_C14436.pdf>`_ in english. Troubleshooting
-the SI24R1 may require `replacing the onboard antenna with a wire
-<https://forum.mysensors.org/post/96871>`_. Furthermore, the Si24R1 has different power
+article and its links might help <https://hackaday.com/2015/02/23/nordic-nrf24l01-real-vs-fake/>`_).
+The most notable clone is the `Si24R1 <https://lcsc.com/product-detail/RF-Transceiver-ICs_Nanjing-Zhongke-Microelectronics-Si24R1_C14436.html>`_.
+I could not find the `Si24R1 datasheet <https://datasheet.lcsc.com/szlcsc/1811142211_Nanjing-Zhongke-Microelectronics-Si24R1_C14436.pdf>`_
+in english. Troubleshooting
+the SI24R1 may require `replacing the onboard antenna with a wire <https://forum.mysensors.org/post/96871>`_.
+Furthermore, the Si24R1 has different power
 amplifier options as noted in the `RF_PWR section (bits 0 through 2) of the RF_SETUP register
-(address 0x06) of the datasheet <https://datasheet.lcsc.com/szlcsc/
-1811142211_Nanjing-Zhongke-Microelectronics-Si24R1_C14436.pdf#%5B%7B%22num%22%3A329%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C755%2Cnull%5D>`_.
+(address 0x06) of the datasheet <https://datasheet.lcsc.com/szlcsc/1811142211_Nanjing-Zhongke-Microelectronics-Si24R1_C14436.pdf#%5B%7B%22num%22%3A329%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C755%2Cnull%5D>`_.
 While the options' values differ from those identified by this library's API, the
 underlying commands to configure those options are almost identical to the nRF24L01.
 The Si24R1 is also famous for not supporting :py:attr:`~circuitpython_nrf24l01.rf24.RF24.auto_ack`
@@ -351,11 +346,10 @@ Future Project Ideas/Additions
 The following are only ideas; they are not currently supported by this circuitpython library.
 
 * `There's a few blog posts by Nerd Ralph demonstrating how to use the nRF24L01 via 2 or 3
-  pins <http://nerdralph.blogspot.com/2015/05/nrf24l01-control-with-2-mcu-pins-using.
-  html>`_ (uses custom bitbanging SPI functions and an external circuit involving a
+  pins <http://nerdralph.blogspot.com/2015/05/nrf24l01-control-with-2-mcu-pins-using.html>`_
+  (uses custom bit-banging SPI functions and an external circuit involving a
   resistor and a capacitor)
-* TCI/IP OSI layer, maybe something like `TMRh20's RF24Ethernet
-  <http://nRF24.github.io/RF24Ethernet/>`_
+* TCI/IP OSI layer, maybe something like `TMRh20's RF24Ethernet <http://nRF24.github.io/RF24Ethernet/>`_
 
 Sphinx documentation
 -----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -172,7 +172,7 @@ to the MCU via a digital input pin during the interrupt example.
     SCK, SCK, "GPIO11 (SCK)"
     MOSI, MOSI, "GPIO10 (MOSI)"
     MISO, MISO, "GPIO9 (MISO)"
-    IRQ, D12, GPIO12
+    IRQ, D12, GPIO24
 
 .. tip::
     User reports and personal experiences have improved results if there is a capacitor of

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -157,7 +157,7 @@ version:
 * :attr:`~circuitpython_nrf24l01.rf24.RF24.pa_level` is available, but it will not accept a `list` or `tuple`.
 * `start_carrier_wave()`, & `stop_carrier_wave()` removed. These only perform a
   test of the nRF24L01's hardware. `rpd` is still available.
-* All comments and docstrings removed, meaning ``help()`` will not provide any specific
+* All comments and doc comments removed, meaning ``help()`` will not provide any specific
   information. Exception prompts have also been reduced and adjusted accordingly.
 * Cannot switch between different radio configurations using context manager (the `with`
   blocks). It is advised that only one `RF24` object be instantiated when RAM is limited

--- a/examples/nrf24l01_ack_payload_test.py
+++ b/examples/nrf24l01_ack_payload_test.py
@@ -140,9 +140,9 @@ def slave(timeout=6):
             buffer = b"World \0" + bytes([counter[0]])  # build new ACK
             nrf.load_ack(buffer, 1)  # load ACK for next response
 
-    # recommended behavior is to keep in TX mode while idle
-    nrf.listen = False  # put radio in TX mode
-    nrf.flush_tx()  # flush any ACK payloads that remain
+    # recommended behavior is to keep in TX mode when in idle
+    nrf.listen = False  # enter inactive TX mode
+    # entering TX mode (when ACK payloads are enabled) also flushes the TX FIFO
 
 
 def set_role():

--- a/examples/nrf24l01_interrupt_test.py
+++ b/examples/nrf24l01_interrupt_test.py
@@ -165,8 +165,7 @@ def set_role():
 
 
 print(
-    "    nRF24L01 Interrupt pin test\n"
-    "    Make sure the IRQ pin is connected to the MCU"
+    "    nRF24L01 Interrupt pin test\n    Make sure the IRQ pin is connected to the MCU"
 )
 
 if __name__ == "__main__":

--- a/examples/nrf24l01_interrupt_test.py
+++ b/examples/nrf24l01_interrupt_test.py
@@ -70,13 +70,14 @@ def _ping_and_prompt() -> bool:
     """transmit 1 payload, wait till irq_pin goes active, print IRQ status
     flags."""
     nrf.ce_pin = True  # tell the nRF24L01 to prepare sending a single packet
-    time.sleep(0.00001)  # mandatory 10 microsecond pulse starts transmission
-    nrf.ce_pin = False  # end 10 us pulse; use only 1 buffer from TX FIFO
+    # There is a mandatory 10 microsecond pulse to start transmission.
+    # We'll leave ce_pin True until ACK packet is received or transmission failed.
     timeout = time.monotonic() + 1
     while IRQ_PIN.value:
         # IRQ pin is active when LOW
         if time.monotonic() > timeout:
             break
+    nrf.ce_pin = False  # exits active TX mode (ignores ACK packets also)
     if IRQ_PIN.value:
         print("   IRQ pin was not triggered!")
         return False

--- a/examples/nrf24l01_interrupt_test.py
+++ b/examples/nrf24l01_interrupt_test.py
@@ -130,12 +130,13 @@ def slave(timeout=6):  # will listen for 6 seconds before timing out
     while not nrf.fifo(0, 0) and time.monotonic() - start_timer < timeout:
         # if RX FIFO is not full and timeout is not reached, then keep going
         pass
-    nrf.listen = False  # put nRF24L01 in Standby-I mode when idling
+    # recommended behavior is to keep in TX mode when in idle
+    nrf.listen = False  # enter inactive TX mode
+    # entering TX mode (when ACK payloads are enabled) also flushes the TX FIFO
     if not nrf.fifo(False, True):  # if RX FIFO is not empty
         # all 3 payloads received were 5 bytes each, and RX FIFO is full
         # so, fetching 15 bytes from the RX FIFO also flushes RX FIFO
         print("Complete RX FIFO:", nrf.read(15))
-    nrf.flush_tx()  # discard any pending ACK payloads
 
 
 def set_role():

--- a/examples/nrf24l01_interrupt_test.py
+++ b/examples/nrf24l01_interrupt_test.py
@@ -7,22 +7,35 @@ nRF24L01
 
 import time
 import board
-import digitalio
+from digitalio import DigitalInOut
 
 # if running this on a ATSAMD21 M0 based board
 # from circuitpython_nrf24l01.rf24_lite import RF24
 from circuitpython_nrf24l01.rf24 import RF24
 
-# select your digital input pin that's connected to the IRQ pin on the nRF4L01
-irq_pin = digitalio.DigitalInOut(board.D12)
-irq_pin.switch_to_input()  # make sure its an input object
-# change these (digital output) pins accordingly
-CE_PIN = digitalio.DigitalInOut(board.D4)
-CSN_PIN = digitalio.DigitalInOut(board.D5)
+# invalid default values for scoping
+SPI_BUS, CSN_PIN, CE_PIN = (None, None, None)
 
-# using board.SPI() automatically selects the MCU's
-# available SPI pins, board.SCK, board.MOSI, board.MISO
-SPI_BUS = board.SPI()  # init spi bus object
+try:  # on Linux
+    import spidev
+
+    SPI_BUS = spidev.SpiDev()  # for a faster interface on linux
+    CSN_PIN = 0  # use CE0 on default bus (even faster than using any pin)
+    CE_PIN = DigitalInOut(board.D22)  # using pin gpio22 (BCM numbering)
+    IRQ_PIN = DigitalInOut(board.D24)  # using gpio24 (BCM numbering)
+
+except ImportError:  # on CircuitPython only
+    # using board.SPI() automatically selects the MCU's
+    # available SPI pins, board.SCK, board.MOSI, board.MISO
+    SPI_BUS = board.SPI()  # init spi bus object
+
+    # change these (GPIO) pins accordingly
+    CE_PIN = DigitalInOut(board.D4)
+    CSN_PIN = DigitalInOut(board.D5)
+    IRQ_PIN = DigitalInOut(board.D12)
+
+# select your digital input pin that's connected to the IRQ pin on the nRF4L01
+IRQ_PIN.switch_to_input()  # make sure its an input object
 
 # we'll be using the dynamic payload size feature (enabled by default)
 # initialize the nRF24L01 on the spi bus object
@@ -53,21 +66,29 @@ nrf.open_tx_pipe(address[radio_number])  # always uses pipe 0
 nrf.open_rx_pipe(1, address[not radio_number])  # using pipe 1
 
 
-def _ping_and_prompt():
+def _ping_and_prompt() -> bool:
     """transmit 1 payload, wait till irq_pin goes active, print IRQ status
     flags."""
-    nrf.ce_pin = 1  # tell the nRF24L01 to prepare sending a single packet
+    nrf.ce_pin = True  # tell the nRF24L01 to prepare sending a single packet
     time.sleep(0.00001)  # mandatory 10 microsecond pulse starts transmission
-    nrf.ce_pin = 0  # end 10 us pulse; use only 1 buffer from TX FIFO
-    while irq_pin.value:  # IRQ pin is active when LOW
-        pass
-    print("IRQ pin went active LOW.")
+    nrf.ce_pin = False  # end 10 us pulse; use only 1 buffer from TX FIFO
+    timeout = time.monotonic() + 1
+    while IRQ_PIN.value:
+        # IRQ pin is active when LOW
+        if time.monotonic() > timeout:
+            break
+    if IRQ_PIN.value:
+        print("   IRQ pin was not triggered!")
+        return False
+    # else:
+    print("    IRQ pin went active LOW.")
     nrf.update()  # update irq_d? status flags
     print(
-        "\tirq_ds: {}, irq_dr: {}, irq_df: {}".format(
+        "    irq_ds: {}, irq_dr: {}, irq_df: {}".format(
             nrf.irq_ds, nrf.irq_dr, nrf.irq_df
         )
     )
+    return True
 
 
 def master():
@@ -83,16 +104,16 @@ def master():
     # on data ready test
     print("\nConfiguring IRQ pin to only ignore 'on data sent' event")
     nrf.interrupt_config(data_sent=False)
-    print("    Pinging slave node for an ACK payload...", end=" ")
-    _ping_and_prompt()  # CE pin is managed by this function
-    print('\t"on data ready" event test {}successful'.format("un" * nrf.irq_dr))
+    print("  Pinging slave node for an ACK payload...")
+    if _ping_and_prompt():  # CE pin is managed by this function
+        print('  "on data ready" event test', "passed" if nrf.irq_dr else "failed")
 
     # on data sent test
     print("\nConfiguring IRQ pin to only ignore 'on data ready' event")
     nrf.interrupt_config(data_recv=False)
-    print("    Pinging slave node again...             ", end=" ")
-    _ping_and_prompt()  # CE pin is managed by this function
-    print('\t"on data sent" event test {}successful'.format("un" * nrf.irq_ds))
+    print("  Pinging slave node again...")
+    if _ping_and_prompt():  # CE pin is managed by this function
+        print('  "on data sent" event test', "passed" if nrf.irq_ds else "failed")
 
     # trigger slave node to exit by filling the slave node's RX FIFO
     print("\nSending one extra payload to fill RX FIFO on slave node.")
@@ -108,11 +129,11 @@ def master():
     # on data fail test
     print("\nConfiguring IRQ pin to go active for all events.")
     nrf.interrupt_config()
-    print("    Sending a ping to inactive slave node...", end=" ")
+    print("  Sending a ping to inactive slave node...")
     nrf.flush_tx()  # just in case any previous tests failed
     nrf.write(b"Dummy", write_only=True)  # CE pin is left LOW
-    _ping_and_prompt()  # CE pin is managed by this function
-    print('\t"on data failed" event test {}successful'.format("un" * nrf.irq_df))
+    if _ping_and_prompt():  # CE pin is managed by this function
+        print('  "on data failed" event test', "passed" if nrf.irq_df else "failed")
     nrf.flush_tx()  # flush artifact payload in TX FIFO from last test
     # all 3 ACK payloads received were 4 bytes each, and RX FIFO is full
     # so, fetching 12 bytes from the RX FIFO also flushes RX FIFO
@@ -130,6 +151,7 @@ def slave(timeout=6):  # will listen for 6 seconds before timing out
     while not nrf.fifo(0, 0) and time.monotonic() - start_timer < timeout:
         # if RX FIFO is not full and timeout is not reached, then keep going
         pass
+    time.sleep(0.0005)  # wait for ACK packet to finish transmitting
     # recommended behavior is to keep in TX mode when in idle
     nrf.listen = False  # enter inactive TX mode
     # entering TX mode (when ACK payloads are enabled) also flushes the TX FIFO

--- a/examples/nrf24l01_manual_ack_test.py
+++ b/examples/nrf24l01_manual_ack_test.py
@@ -142,7 +142,7 @@ def slave(timeout=6):
             start_timer = time.monotonic()  # reset timeout
 
     # recommended behavior is to keep in TX mode when in idle
-    nrf.listen = False  # put the nRF24L01 in TX mode + Standby-I power state
+    nrf.listen = False  # enter inactive TX mode
 
 
 def set_role():

--- a/examples/nrf24l01_network_test.py
+++ b/examples/nrf24l01_network_test.py
@@ -123,6 +123,9 @@ def idle(timeout: int = 30, strict_timeout: bool = False):
             if not strict_timeout:
                 start_timer = time.monotonic()  # reset timer
             frame = nrf.read()
+            if frame is None:
+                # should never get here because we check network.available() first
+                continue
             message_len = len(frame.message)
             print("Received payload", end=" ")
             # TMRh20 examples only use 1 or 2 long ints as small messages
@@ -220,7 +223,7 @@ if __name__ == "__main__":
             pass  # continue example until 'Q' is entered
     except KeyboardInterrupt:
         print(" Keyboard Interrupt detected. Powering down radio...")
-        nrf.power = 0
+        nrf.power = False
 elif nrf.node_address != NETWORK_DEFAULT_ADDR:
     print("    Run emit(<node number>) to transmit.")
     print("    Run idle() to receive or forward messages in the network.")

--- a/examples/nrf24l01_simple_test.py
+++ b/examples/nrf24l01_simple_test.py
@@ -116,7 +116,7 @@ def slave(timeout=6):
             start = time.monotonic()
 
     # recommended behavior is to keep in TX mode while idle
-    nrf.listen = False  # put the nRF24L01 is in TX mode
+    nrf.listen = False  # enter inactive TX mode
 
 
 def set_role():

--- a/examples/nrf24l01_stream_test.py
+++ b/examples/nrf24l01_stream_test.py
@@ -154,7 +154,7 @@ def slave(timeout=5):
             start_timer = time.monotonic()  # reset timer on every RX payload
 
     # recommended behavior is to keep in TX mode while idle
-    nrf.listen = False  # put the nRF24L01 is in TX mode
+    nrf.listen = False  # enter inactive TX mode
 
 
 def set_role():

--- a/examples/nrf24l01_stream_test.py
+++ b/examples/nrf24l01_stream_test.py
@@ -126,8 +126,7 @@ def master_fifo(count=1, size=32):
                     if failures > 99 and buf_iter < 7 and cnt < 2:
                         # we need to prevent an infinite loop
                         print(
-                            "Make sure slave() node is listening."
-                            " Quiting master_fifo()"
+                            "Make sure slave() node is listening. Quiting master_fifo()"
                         )
                         buf_iter = size + 1  # be sure to exit the while loop
                         nrf.flush_tx()  # discard all payloads in TX FIFO

--- a/examples/nrf24l01_stream_test.py
+++ b/examples/nrf24l01_stream_test.py
@@ -91,7 +91,7 @@ def master(count=1, size=32):  # count = 5 will transmit the list 5 times
         # most for payloads that fail to transmit.
         result = nrf.send(buffers, force_retry=2)  # result is a list
         end_timer = time.monotonic_ns()  # end timer
-        print("Transmission took", (end_timer - start_timer) / 1000, "us")
+        print("Transmission took", (end_timer - start_timer) / 1000000, "ms")
         for r in result:  # tally the resulting success rate
             successful += 1 if r else 0
     print(
@@ -103,39 +103,42 @@ def master(count=1, size=32):  # count = 5 will transmit the list 5 times
 def master_fifo(count=1, size=32):
     """Similar to the `master()` above except this function uses the full
     TX FIFO and `RF24.write()` instead of `RF24.send()`"""
-    buf = make_buffers(size)  # make a list of payloads
-    nrf.listen = False  # ensures the nRF24L01 is in TX mode
+    payloads = make_buffers(size)  # make a list of payloads
+    nrf.listen = False  # enter inactive TX mode
     for cnt in range(count):  # transmit the same payloads this many times
         nrf.flush_tx()  # clear the TX FIFO so we can use all 3 levels
-        # NOTE the write_only parameter does not initiate sending
-        buf_iter = 0  # iterator of payloads for the while loop
         failures = 0  # keep track of manual retries
         start_timer = time.monotonic_ns()  # start timer
-        while buf_iter < size:  # cycle through all the payloads
-            nrf.ce_pin = False
-            while buf_iter < size and nrf.write(buf[buf_iter], write_only=1):
+        for buf in payloads:
+            while not nrf.write(buf):
                 # NOTE write() returns False if TX FIFO is already full
-                buf_iter += 1  # increment iterator of payloads
-            nrf.ce_pin = True
-            while not nrf.fifo(True, True):  # updates irq_df flag
-                if nrf.irq_df:
-                    # reception failed; we need to reset the irq_rf flag
-                    nrf.ce_pin = False  # fall back to Standby-I mode
+                if nrf.irq_df:  # reception failed; TX FIFO is locked
                     failures += 1  # increment manual retries
-                    nrf.clear_status_flags()  # clear the irq_df flag
-                    if failures > 99 and buf_iter < 7 and cnt < 2:
-                        # we need to prevent an infinite loop
-                        print(
-                            "Make sure slave() node is listening. Quiting master_fifo()"
-                        )
-                        buf_iter = size + 1  # be sure to exit the while loop
-                        nrf.flush_tx()  # discard all payloads in TX FIFO
-                    else:
-                        nrf.ce_pin = True  # start re-transmitting
-        nrf.ce_pin = False
+                    # we need to reset the irq_rf flag and the radio's CE pin
+                    nrf.ce_pin = False  # fall back to Standby-I mode
+                    # NOTE next call to nrf.write() will
+                    # nrf.clear_status_flags()  # clear the irq_df flag
+                    # nrf.ce_pin = True  # restart transmissions
+                if failures > 49:
+                    break  # prevent infinite loop
+            if failures > 49:
+                # exit early because RX side seems absent
+                nrf.flush_tx()  # discard all payloads in TX FIFO
+                print("Make sure slave() node is listening. Quitting master_fifo()")
+                break
+        # wait for radio to finish transmitting everything in the TX FIFO
+        while failures < 49 and not nrf.fifo(about_tx=True, check_empty=True):
+            # fifo() also update()s the StatusFlags
+            if nrf.irq_df:
+                failures += 1
+                # manually restart transmissions because where done write()ing
+                nrf.ce_pin = False
+                nrf.clear_status_flags()
+                nrf.ce_pin = True
         end_timer = time.monotonic_ns()  # end timer
+        nrf.ce_pin = False  # enter inactive TX mode
         print(
-            "Transmission took {} us".format((end_timer - start_timer) / 1000),
+            "Transmission took {} ms".format((end_timer - start_timer) / 1000000),
             "with {} failures detected.".format(failures),
         )
 
@@ -148,7 +151,7 @@ def slave(timeout=5):
     while time.monotonic() < start_timer + timeout:
         if nrf.available():
             count += 1
-            # retreive the received packet's payload
+            # retrieve the received packet's payload
             buffer = nrf.read()  # clears flags & empties RX FIFO
             print("Received:", buffer, "-", count)
             start_timer = time.monotonic()  # reset timer on every RX payload
@@ -164,7 +167,7 @@ def set_role():
     user_input = (
         input(
             "*** Enter 'R' for receiver role.\n"
-            "*** Enter 'T' for transmitter role (using 1 level  of the TX FIFO).\n"
+            "*** Enter 'T' for transmitter role (using 1 level of the TX FIFO).\n"
             "*** Enter 'F' for transmitter role (using all 3 levels of the TX FIFO).\n"
             "*** Enter 'Q' to quit example.\n"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
 [project]
 name = "circuitpython-nrf24l01"
 requires-python = ">=3.7"
-description = "Circuitpython driver library for the nRF24L01 transceiver"
+description = "CircuitPython driver library for the nRF24L01 transceiver"
 readme = "README.rst"
 authors = [
     {name = "Brendan Doherty", email = "2bndy5@gmail.com"}

--- a/tests/test_fake_ble.py
+++ b/tests/test_fake_ble.py
@@ -35,7 +35,7 @@ def test_lvl_mask(lvl: int, expected: int):
 
 
 def test_whitener(ble_obj: FakeBLE):
-    """test whitening and dewhitening an arbitrary buffer."""
+    """test whitening and de-whitening an arbitrary buffer."""
     buf = os.urandom(24)
     for freq in range(3):
         coef = (freq + 37) | 0x40
@@ -65,7 +65,7 @@ def test_rev_bits():
 def test_ble_mac(ble_obj: FakeBLE, addr: Optional[Union[int, bytes]]):
     """test the FakeBLE mac attribute."""
     assert isinstance(ble_obj.mac, (bytes, bytearray))
-    ble_obj.mac = addr
+    ble_obj.mac = addr  # type: ignore[assignment]
     assert ble_obj.mac is not None and len(ble_obj.mac) == 6
     if addr is not None:
         if isinstance(addr, int):
@@ -86,7 +86,7 @@ def test_ble_mac(ble_obj: FakeBLE, addr: Optional[Union[int, bytes]]):
 )
 def test_name(ble_obj: FakeBLE, name: Optional[Union[str, bytes, int]]):
     """test FakeBLE name attribute."""
-    ble_obj.name = name
+    ble_obj.name = name  # type: ignore[assignment]
     if isinstance(name, str):
         assert name.encode(encoding="utf-8") == ble_obj.name
     else:
@@ -103,7 +103,7 @@ def test_name(ble_obj: FakeBLE, name: Optional[Union[str, bytes, int]]):
 def test_show_pa_level(ble_obj: FakeBLE, name: Optional[Union[str, bytes, int]]):
     """test FakeBLE show_pa_level attribute."""
     assert not ble_obj.show_pa_level
-    ble_obj.name = name
+    ble_obj.name = name  # type: ignore[assignment]
     ble_obj.show_pa_level = True
     assert ble_obj.show_pa_level
 
@@ -169,11 +169,12 @@ def inject_rx_payload(ble_obj: FakeBLE, monkeypatch: pytest.MonkeyPatch):
     return repr(service_data)
 
 
-def test_rx_payload(ble_obj: FakeBLE, inject_rx_payload: pytest.fixture):
+def test_rx_payload(ble_obj: FakeBLE, inject_rx_payload: pytest.fixture):  # type: ignore
     """test available() and read()"""
     buf_repr = inject_rx_payload
     assert ble_obj.available()
     payload = ble_obj.read()
+    assert payload
     assert payload.mac == ble_obj.mac
     assert payload.name == "test"
     assert not payload.pa_level

--- a/tests/test_rf24.py
+++ b/tests/test_rf24.py
@@ -26,7 +26,7 @@ def test_context(rf24_obj: RF24, ble_obj: FakeBLE):
 
 
 @pytest.mark.parametrize("value", [True, False])
-def test_ce(rf24_obj: RF24, value: False):
+def test_ce(rf24_obj: RF24, value: bool):
     """test ce_pin attribute."""
     rf24_obj.ce_pin = value
     assert rf24_obj.ce_pin == value
@@ -156,7 +156,7 @@ def test_dyn_pl_attr(rf24_obj: RF24):
     """test dynamic_payloads attribute (using list of integers)."""
     enable = [1, -1, 0, 1]
     previous = rf24_obj.dynamic_payloads & enable.index(-1)
-    rf24_obj.dynamic_payloads = enable
+    rf24_obj.dynamic_payloads = enable  # type: ignore[assignment]
     for i, pipe in enumerate(enable):
         if pipe < 0:
             assert rf24_obj.get_dynamic_payloads(i) == previous
@@ -177,7 +177,7 @@ def test_payload_length_attr(rf24_obj: RF24):
     """test payload_length attribute (using list of integers)."""
     enable = [1, -1, 20, 0]
     previous = rf24_obj.payload_length
-    rf24_obj.payload_length = enable
+    rf24_obj.payload_length = enable  # type: ignore[assignment]
     for i, pipe in enumerate(enable):
         if pipe <= 0:
             assert rf24_obj.get_payload_length(i) == previous
@@ -198,7 +198,7 @@ def test_auto_ack_attr(rf24_obj: RF24):
     """test auto_ack attribute (using list of integers)."""
     enable = [1, -1, 20, 0]
     previous = bool(rf24_obj.auto_ack & (enable.index(-1)))
-    rf24_obj.auto_ack = enable
+    rf24_obj.auto_ack = enable  # type: ignore[assignment]
     for i, pipe in enumerate(enable):
         if pipe < 0:
             assert rf24_obj.get_auto_ack(i) == previous

--- a/tests/test_rf24.py
+++ b/tests/test_rf24.py
@@ -1,8 +1,8 @@
 """Test functions related to core RF24 functionality."""
 
-from typing import Optional
+from typing import Optional, Union
 import pytest
-from circuitpython_nrf24l01.rf24 import RF24
+from circuitpython_nrf24l01.rf24 import RF24, FIFO_EMPTY, FIFO_FULL, FIFO_OCCUPIED
 from circuitpython_nrf24l01.fake_ble import FakeBLE
 
 
@@ -299,3 +299,49 @@ def test_carrier_functions(rf24_obj: RF24, monkeypatch: pytest.MonkeyPatch):
     assert not rf24_obj.power
     assert not rf24_obj.ce_pin
     assert not rf24_obj._spi._spi.state.registers[6][0] & 0x90
+
+
+@pytest.mark.parametrize(
+    "reg_val,expected,about_tx,check_empty",
+    [
+        # raw RX state
+        (0x1, FIFO_EMPTY, False, None),
+        (0x2, FIFO_FULL, False, None),
+        (0, FIFO_OCCUPIED, False, None),
+        # raw TX state
+        (0x10, FIFO_EMPTY, True, None),
+        (0x20, FIFO_FULL, True, None),
+        (0, FIFO_OCCUPIED, True, None),
+        # simplified RX state
+        (0x1, bool(FIFO_EMPTY), False, True),  # is empty
+        (0x2, bool(FIFO_FULL), False, False),  # is full
+        # simplified TX state
+        (0x10, bool(FIFO_EMPTY), True, True),  # is empty
+        (0x20, bool(FIFO_FULL), True, False),  # is full
+        # simulated binary corrupted MISO
+        pytest.param(3, 3, False, None, marks=pytest.mark.xfail),
+    ],
+    ids=[
+        "RX_EMPTY",
+        "RX_FULL",
+        "RX_OCCUPIED",
+        "TX_EMPTY",
+        "TX_FULL",
+        "TX_OCCUPIED",
+        "bool(RX_EMPTY)",
+        "bool(RX_FULL)",
+        "bool(TX_EMPTY)",
+        "bool(TX_FULL)",
+        "bin-corruption",
+    ],
+)
+def test_fifo_state(
+    rf24_obj,
+    reg_val: int,
+    expected: Union[int, bool],
+    about_tx: bool,
+    check_empty: Optional[bool],
+):
+    """check the fifo state is accurately described"""
+    rf24_obj._spi._spi.state.registers[0x17][0] = reg_val
+    assert expected == rf24_obj.fifo(about_tx=about_tx, check_empty=check_empty)


### PR DESCRIPTION
As usual, I'm porting some of the recent updates to pure python.

## Relevant updates (from upstream C++ counterparts)
- more performant SPI transactions; nRF24/RF24#988
- refactored `RF24.fifo()` to throw `RuntimeError` on observed binary corruption over MISO. Also added convenient constants to give meaning to returned "magic" numbers. nRF24/RF24#1009
- fixed persistent TX address used on RX pipe 0. This only occurred when pipe 0 was used for RX and the radio changed from RX to TX mode. nRF24/RF24#1029
- use new reserved message types (`NETWORK_OVERRUN` and `NETWORK_CORRUPTION`) to propagate errors up the wireless stack (instead of ignoring them) from `RF24Network.update()` or `RF24Mesh.update()`. nRF24/RF24Network#249 and nRF24/RF24Network#250

## While I was at it
- revised streaming data example about error handling when using the full TX FIFO.
- revised interrupt example: made work on Linux and fixed RX role
- doc updates (of course)
- added a test
- updated type checking in tests and a couple in RF24 signatures
